### PR TITLE
Required `secret` param isn\'t set (php 7)

### DIFF
--- a/ReCaptchaValidator.php
+++ b/ReCaptchaValidator.php
@@ -42,7 +42,8 @@ class ReCaptchaValidator extends Validator
     {
         parent::init();
         if (empty($this->secret)) {
-            if (!empty(Yii::$app->reCaptcha->secret)) {
+            $variable = Yii::$app->reCaptcha->secret; //put result of magic methot in variable
+            if (!empty($variable)) { //check for empty
                 $this->secret = Yii::$app->reCaptcha->secret;
             } else {
                 throw new InvalidConfigException('Required `secret` param isn\'t set.');


### PR DESCRIPTION
When i update my local php from 5.6 to 7 i got this error, because !empty( Yii::$app->reCaptcha->secret;) - rerutns only FALSE